### PR TITLE
Update Dockerfile entry point

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ COPY . .
 
 RUN pdm install
 
-ENTRYPOINT [ "/app/run-bot.sh"]
+ENTRYPOINT [ "pdm", "run", "alfred" ]


### PR DESCRIPTION
Updates the Dockerfile to use `pdm run alfred` instead of the old `run-bot.sh` script.